### PR TITLE
Creating new user results in Internal Server Error

### DIFF
--- a/src/HateoasInc/Bundle/ExampleBundle/Tests/API/UsersTest.php
+++ b/src/HateoasInc/Bundle/ExampleBundle/Tests/API/UsersTest.php
@@ -152,6 +152,37 @@ class UsersTest extends ApiTestCase
 
     /**
      * @param \stdClass $doc
+     * @depends testGettingOne200
+     */
+    public function testPostingOne200()
+    {
+        /* Given... (Fixture) */
+        $coffeeGroup
+            = self::$fixtures['social']->getReference('coffee-group');
+        $url = $this->getRootUrl() . self::RESOURCE_PATH;
+        $body = ['users' => [
+            'username' => "new_guy",
+            'password' => "12345",
+            'email' => "new_guy@christmastown.org",
+            'name' => "John",
+            'surname' => "Doe",
+            'links' => [
+                'user-groups' => [$coffeeGroup->getId()]
+            ]
+        ]];
+        $client = $this->buildHttpClient($url, 'the_other_guy', 'b4dp4ssw0rd')
+            ->setMethod('POST')
+            ->setBody($body);
+        /* When... (Action) */
+        $transfer = $client->exec();
+        /* Then... (Assertions) */
+        $message = $transfer . "\n";
+        $this->assertResponseOK($client, $message);
+        $this->assertJsonApiSchema($transfer, $message);
+    }
+
+    /**
+     * @param \stdClass $doc
      * @depends testPuttingOne200
      */
     public function testPuttingOne403(\stdClass $doc)


### PR DESCRIPTION
When trying to create a new user you get Internal Server Error and this warning: "Warning: Illegal offset type in unset in vendor/gointegro/hateoas/GoIntegro/Hateoas/Entity/DefaultBuilder.php line 128"

The line in question is https://github.com/GoIntegro/hateoas/blob/master/Entity/DefaultBuilder.php#L128
I wonder what is your intention here. Why are you resetting relationships and metadata in the loop? And obviously why are you using arrays as keys to $fileds?
